### PR TITLE
fixed xunit parsing bug for ypaths that have comma in them

### DIFF
--- a/src/main/java/brickhouse/udf/xunit/GetYPathSegmentsUDF.java
+++ b/src/main/java/brickhouse/udf/xunit/GetYPathSegmentsUDF.java
@@ -99,7 +99,11 @@ public class GetYPathSegmentsUDF extends GenericUDF {
         List<String> segments = new ArrayList<String>();
 
         String xunit = elementOI.getPrimitiveJavaObject(arguments[0].get());
-        for( String ypath: xunit.split(",")) {
+        // some ypaths have comma in the ypath so handle such ypaths accordingly
+        for( String ypath: xunit.split(",/")) {
+           if(! ypath.startsWith("/"))
+               ypath = "/" + ypath;
+
             String[] ypathParts = ypath.split("/");
             String parentPart = ypath.length() > 1 ? "/"+ ypathParts[1] : null;
             if (SEGMENTABLE_YPATH_LIST.contains(parentPart)) {


### PR DESCRIPTION
During production ETL run, a xunit parsing bug was exposed in the getsegments UDF. A comma in the ypath of an xunit was breaking the code:
device/p=APP/manufacturer=NA/dev=HUAWEI G700-T00(Huawei G700-T00 hwG700-T00:4.2.1 HuaweiG700-T00 C00B124:user ota-rel-keys,release-keys) AppEngine-Google